### PR TITLE
update park agent to use ReAct response parser

### DIFF
--- a/assets/ui/page/playground/tools.py
+++ b/assets/ui/page/playground/tools.py
@@ -211,6 +211,8 @@ def tool_chat_page():
         def response_generator(turn_response):
             if st.session_state.get("agent_type") == AgentType.REACT:
                 return _handle_react_response(turn_response)
+            elif st.session_state.get("agent_type") == AgentType.PARKS:
+                return _handle_react_response(turn_response)
             else:
                 return _handle_regular_response(turn_response)
 


### PR DESCRIPTION
Updated the Parks Agents so that its output is parsed the same way as the ReAct agent. See example below.

![Screenshot 2025-05-19 at 3 12 46 PM](https://github.com/user-attachments/assets/9a803195-c90e-4b5d-8c23-ad5557291e05)
